### PR TITLE
contact.md: Rework IRC section

### DIFF
--- a/contact.md
+++ b/contact.md
@@ -12,15 +12,11 @@ categories: megaglest
 If you want to report a bug you can do it in the forum but before look at this:
 
 [**How to report problems/bugs**](https://forum.megaglest.org/index.php?topic=5332.0)
+
 ## IRC
 
-Host: irc.megaglest.org (Freenode IRC network)
+#MegaGlest on [Libera Chat](https://libera.chat) ([webchat](https://web.libera.chat/#megaglest))
 
-Port: 6667
-
-Channel: #MegaGlest
-
-[**Webchat**](http://chat.megaglest.org/)
 ## Mailing list
 
 megaglest-developers[at]lists.sourceforge.net


### PR DESCRIPTION
The project moved to libera some time ago and even got a project registration here. This updates some outdated information still referring to freenode.

I made the section much shorter and removed redundant information. All the information on how to connect, the ports and more is all on the Libera Chat website so we do not need to duplicate it, but there is still the webchat which works without any setup.

There is unfortunately no need for the HTTP redirect on `chat.megaglest.org`, as there is no reason to not directly link to the webchat for the sake of both transparency (seeing where clicking the webchat link leads you) and simplicity (maintaining a HTTP redirect requires little but still a non-zero amount of maintenance). Connecting through `irc.megaglest.org` may also give users certificate troubles, so this is one more reason why referring the user to Libera Chat's own docs is better than duplicating information and using megaglest-branded URLs.